### PR TITLE
fix: when extra / present in virtual host name

### DIFF
--- a/faststream/rabbit/utils.py
+++ b/faststream/rabbit/utils.py
@@ -36,7 +36,7 @@ def build_url(
         port=port or original_url.port or default_port,
         login=login or original_url.user or "guest",
         password=password or original_url.password or "guest",
-        virtualhost=virtualhost or original_url.path.lstrip("/"),
+        virtualhost=virtualhost or original_url.path.replace("/", "", 1),
         ssl=use_ssl,
         ssl_options=ssl_options,
         client_properties=client_properties,


### PR DESCRIPTION
e.g name of vh is  "/test"

there is no problenm if passing vh separately, result url will "amqp://root:123@localhost:5672//test"

but if pass vh in uri, result uri will 
"amqp://root:123@localhost:5672/test"
cause lstrip("/") calling and slash missing in result url,  so replace with count 1 is ok
